### PR TITLE
Add Host proxy header

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,0 @@
-/* https://track.customer.io/:splat 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/*"
+  to = "https://track.customer.io/:splat"
+  status = 200
+  headers = {Host = "email.tuple.app"}


### PR DESCRIPTION
The nginx proxy server example in the [customer.io docs](https://customer.io/docs/https-link-verification#setting-up-https-link-tracking-with-nginx) specifically includes a 'Host' header. 

My hunch is adding this header to our proxy will make the customer.io validation code happy and solve our _Invalid link security token_ error.

This PR removes the original _redirects file in favor of a [netlify.toml](https://docs.netlify.com/configure-builds/file-based-configuration/#sample-file) file because as best I understand from the [netlify docs](https://docs.netlify.com/routing/redirects/rewrites-proxies/#custom-headers-in-proxy-redirects) redirects can be configured in netlify.toml files but redirect header configurations cannot be added to _redirects files 